### PR TITLE
add Rasdaman credits + fixup styles

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1012,10 +1012,7 @@ footer {
 a {
   text-decoration: underline;
   display: inline-block;
-}
-
-a:hover {
-  background-color: #ffe598;
+  color: #0033CC;
 }
 
 a.button,

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -33,7 +33,13 @@
               >University of Illinois, Urbana-Champaign</a
             >.
           </p>
-
+          <p>
+            This tool uses the
+            <a href="https://doi.org/10.5281/zenodo.1040170"
+              >Rasdaman raster database</a
+            >
+            for data storage, processing, and web services.
+          </p>
           <p>
             Copyright &copy; {{ year }} University of Alaska Fairbanks. All
             rights reserved.
@@ -69,15 +75,25 @@ export default {
 
 <style lang="scss" scoped>
 .footer {
+  a {
+    text-decoration: underline;
+    color: #0033cc;
+  }
+
   box-shadow: inset 0 7px 9px -7px rgba(0, 0, 0, 0.4);
 
   .logo {
-    text-align: center;
+    text-align: right;
+
+    @media screen and (max-width: 768px) {
+      text-align: center;
+    }
+
     img {
       position: relative;
-      top: 0.25rem;
-      width: 75%;
-      max-width: 40vw;
+      top: 1.2rem;
+      width: 60%;
+      max-width: 30vw;
     }
   }
 


### PR DESCRIPTION
To check this...

- Ensure there's a credit blurb for Rasdaman in the footer, check that it links to the Zenodo DOI for Rasdaman
- Compared to the original tool, the links should now be a bit higher-contrast.  Links in the footer should be underlined.
- Switch to Mobile view.  The UAF logo in the footer should be centered.
- In Desktop view, the UAF logo should be a bit smaller than before, and properly vertically-aligned with the rest of the footer.