### PR TITLE
Updates email to our uaf-snap-data-tools@alaska.edu address

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -432,8 +432,10 @@
             >Send us feedback</a
           >
           or email
-          <a href="mailto:nlfresco@alaska.edu">nlfresco@alaska.edu</a> if you
-          have questions.
+          <a href="mailto:uaf-snap-data-tools@alaska.edu"
+            >uaf-snap-data-tools@alaska.edu</a
+          >
+          if you have questions.
         </p>
       </div>
     </section>


### PR DESCRIPTION
Removes nlfresco@alaska.edu from the site and is replaced with our joint email group uaf-snap-data-tools@alaska.edu.

Fixes #33 