### PR TITLE
Updates HSIAA to point at maps.earthmaps.io Varnish cache for the sea ice Rasdaman coverage.

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 VUE_APP_SNAP_API_URL=https://earthmaps.io
-VUE_APP_WMS_URL=https://zeus.snap.uaf.edu/rasdaman/ows
+VUE_APP_WMS_URL=https://maps.earthmaps.io/rasdaman/ows

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
 VUE_APP_SNAP_API_URL=http://127.0.0.1:5000
-VUE_APP_WMS_URL=https://apollo.snap.uaf.edu/rasdaman/ows
+VUE_APP_WMS_URL=https://maps.earthmaps.io/rasdaman/ows


### PR DESCRIPTION
Closes #41 

This PR updates the development and production environment to point at maps.earthmaps.io for the WMS endpoint for the Rasdaman sea ice coverage.