### PR TITLE
Update Umami script URL to v2 version

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
       defer
       data-website-id="a8f7164d-7d69-496a-bc2f-076a59214eb5"
       data-domains="snap.uaf.edu"
-      src="https://umami.snap.uaf.edu/umami.js"
+      src="https://umami.snap.uaf.edu/script.js"
       data-do-not-track="true"
     ></script>
     <title>Historical Sea Ice Atlas</title>


### PR DESCRIPTION
**Note: This change was already merged into the `vue3-hero` branch via PR #47, but it's looking like we'll be upgrading the Umami server to v2 before the `vue3-hero` branch is ready for prime time, so it's important that we update the Umami script URL to the v2 version in the `main` branch in the interim. That's what this PR does.**

This PR updates the Umami script URL to work with Umami v2. I.e., `umami.js` was changed to `script.js`.

You will need the Umami v2 Vagrant VM to test against. If you do not already have this set up, refer to the Vagrant instructions in https://github.com/ua-snap/nccwsc-projects/pull/154.

With the Vagrant VM running, and assuming Umami's port is forwarded to port 9999 of the host, simply change the Umami config in `public/index.html` to:

```
<script
  async
  defer
  data-website-id="a8f7164d-7d69-496a-bc2f-076a59214eb5"
  src="http://localhost:9999/script.js"
  data-do-not-track="true"
></script>
```

Then run HSIAA locally and verify that your traffic shows up here: http://localhost:9999/websites/a8f7164d-7d69-496a-bc2f-076a59214eb5