### PR TITLE
Show "Loading data..." text when data is loading

### DIFF
--- a/src/components/ConcentrationPlot.vue
+++ b/src/components/ConcentrationPlot.vue
@@ -13,7 +13,7 @@
 import Multiselect from '@vueform/multiselect'
 import Plotly from 'plotly.js-dist-min'
 import _ from 'lodash'
-import { ref, computed, watch, toRaw } from 'vue'
+import { ref, computed, watch, toRaw, onMounted } from 'vue'
 import { useAtlasStore } from '@/stores/atlas'
 import { storeToRefs } from 'pinia'
 import { xrange, plotSettings, MIN_YEAR, MAX_YEAR } from '@/shared.js'
@@ -94,6 +94,10 @@ const title = computed(() => {
 	})
 	monthFragment = monthFragment.substring(0, monthFragment.length - 2)
 	return `<b>${atlasStore.getPlaceTitle}, ${monthFragment}</b>`
+})
+
+onMounted(() => {
+	updatePlot()
 })
 
 watch([months, apiData], ([newMonths, newData]) => {

--- a/src/components/Tapestry.vue
+++ b/src/components/Tapestry.vue
@@ -18,7 +18,7 @@
 <script setup>
 import Plotly from 'plotly.js-dist-min'
 import _ from 'lodash'
-import { computed, watch, toRaw } from 'vue'
+import { computed, watch, toRaw, onMounted } from 'vue'
 import { useAtlasStore } from '@/stores/atlas'
 import { storeToRefs } from 'pinia'
 import { xrange, plotSettings, MIN_YEAR, MAX_YEAR } from '@/shared.js'
@@ -102,6 +102,10 @@ const updatePlot = function () {
   // Fire resize event to trigger Plotly responsiveness.
   window.dispatchEvent(new Event('resize'))
 }
+
+onMounted(() => {
+	updatePlot()
+})
 
 watch(apiData, (newData) => {
   updatePlot()

--- a/src/stores/atlas.js
+++ b/src/stores/atlas.js
@@ -17,7 +17,7 @@ export const useAtlasStore = defineStore('atlas', {
       lat: undefined,
       lng: undefined,
       apiData: [],
-      isLoaded: true,
+      isLoaded: false,
       validMapPixel: false
     }
   },
@@ -113,6 +113,7 @@ export const useAtlasStore = defineStore('atlas', {
       this.lng = formatLatLng(value.lng)
     },
     async fetch() {
+      this.isLoaded = false
       let queryUrl = `https://earthmaps.io/seaice/point/${this.lat}/${this.lng}/`
       let response = await axios.get(queryUrl, { timeout: 60000 }).catch((err) => {
         console.error(err)


### PR DESCRIPTION
This PR restores the "Loading data..." message when waiting to receive data for a location, and also fixes a bug that was preventing the charts from loading on initial report page load.

To test, pick a location on the map and make sure you see the "Loading data..." message in two different places on the page (the concentration plot and the tapestry plot) while the data is being fetched. The message should go away once the two types of plots load. Go back, pick another place, and make sure the "Loading data..." message continues to work as expected.