### PR TITLE
Set base URL in Vite config to fix production subpath load issue

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -12,5 +12,6 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     }
-  }
+  },
+  base: process.env.NODE_ENV === "production" ? "/tools/sea-ice-atlas/" : "/",
 })


### PR DESCRIPTION
This PR sets the URL base path in `vite.config.js` to match the `publicPath` set in `vue.config.ts`, adapting to the `NODE_ENV` environment variable in the same way. Without this change, the built & deployed webapp will not load when served from the /tools/sea-ice-atlas subpath.

If you're curious what happens without this change, run the following:

```
git checkout vue3-hero
npm run build
mkdir tools
mv dist tools/sea-ice-atlas
python -m http.server
```

Then visit the webapp at http://localhost:8000/tools/sea-ice-atlas and observe that you get a blank white page with loading errors in the web console.

To verify that this change fixes this problem, run the following:

```
rm -fr tools
git checkout production_path_fix
npm run build
mkdir tools
mv dist tools/sea-ice-atlas
python -m http.server
```

Then, again, visit http://localhost:8000/tools/sea-ice-atlas (and maybe do a shift + reload) and observe that everything works as intended.