### PR TITLE
Check for presence of apiData.value before population charts

### DIFF
--- a/src/components/ConcentrationPlot.vue
+++ b/src/components/ConcentrationPlot.vue
@@ -66,7 +66,7 @@ const layout = computed(() => {
 })
 
 const traces = computed(() => {
-	if (apiData) {
+	if (apiData.value) {
 		let unwrappedApiData = toRaw(apiData.value)
 		let newTraces
 		// Add a series of traces for the season


### PR DESCRIPTION
Closes #70.

This PR changes one line of code that was preventing charts from loading properly for some communities (or probably just intermittently depending on how long it took the API to return sea ice data for the location). Instead of checking if `apiData` (a Vue 3 reference object) exist, it now checks whether `apiData.value` exists to make sure the data from the API is available before attempting to populate the line and canvas charts.

To replicate this, go to our production Historical Sea Ice Atlas app here:

https://snap.uaf.edu/tools/sea-ice-atlas/

Try selecting Utqiagvik from the community dropdown menu. If the charts fail to load properly, look at your browser's console output and you'll see that it's bombing out on a `split` operation that can be traced back to this chunk of code:

```
if (apiData) {
	let unwrappedApiData = toRaw(apiData.value)
	let newTraces
	// Add a series of traces for the season
	newTraces = _.map(months.value, (month) => {
		let y = _.filter(unwrappedApiData, (value, index) => {
			// Convert index to numeric month
			let m = parseInt(index.split('-')[1])
			return m % 12 == month
		})
		return {
			x: xrange,
			y: y,
			type: 'scatter',
			name: monthNames[month]
		}
	})
	return newTraces
}
```

It appears that this is happening because it's attempting to run through the code/split operation before the API data is available.

To test, I've built the app from this `fix_chart_bugs` branch and uploaded it here:

http://hsia-temp.s3-website-us-west-2.amazonaws.com/

Observe that the problem is fixed at the URL above.