### PR TITLE
Required change to allow for December to show up in concentration plot.

### DIFF
--- a/src/components/ConcentrationPlot.vue
+++ b/src/components/ConcentrationPlot.vue
@@ -74,7 +74,7 @@ const traces = computed(() => {
 			let y = _.filter(unwrappedApiData, (value, index) => {
 				// Convert index to numeric month
 				let m = parseInt(index.split('-')[1])
-				return m % 12 == month
+				return m % 13 == month
 			})
 			return {
 				x: xrange,


### PR DESCRIPTION
This PR fixes the logic for identifying the correct month so that it no longer does the modulo of 12 but 13 to catch all 12 months as expected.

To test, choose any point on the Sea Ice map on the production site, and see that when you ask for December in the concentration plot, it doesn't display anything. On this current branch, if you do the same, it will return data.