### PR TITLE
Adds circular mask to frame the data layers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "moment": "^2.29.4",
         "pinia": "^2.1.7",
         "plotly.js-dist-min": "^2.27.0",
+        "proj4": "^2.15.0",
         "proj4leaflet": "^1.0.2",
         "vue": "^3.3.4",
         "vue-router": "^4.2.5",
@@ -2410,12 +2411,12 @@
       }
     },
     "node_modules/proj4": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.9.1.tgz",
-      "integrity": "sha512-hhquvYHnqz8nf8U9CODRLGSL7bUg4p5oVkZI4oWxX7whNcSbn2xdNA1WnF1jye+ezrtuSiPVao9LEHlKeQA5uA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.15.0.tgz",
+      "integrity": "sha512-LqCNEcPdI03BrCHxPLj29vsd5afsm+0sV1H/O3nTDKrv8/LA01ea1z4QADDMjUqxSXWnrmmQDjqFm1J/uZ5RLw==",
       "dependencies": {
         "mgrs": "1.0.0",
-        "wkt-parser": "^1.3.3"
+        "wkt-parser": "^1.4.0"
       }
     },
     "node_modules/proj4leaflet": {
@@ -2954,9 +2955,9 @@
       }
     },
     "node_modules/wkt-parser": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.3.tgz",
-      "integrity": "sha512-ZnV3yH8/k58ZPACOXeiHaMuXIiaTk1t0hSUVisbO0t4RjA5wPpUytcxeyiN2h+LZRrmuHIh/1UlrR9e7DHDvTw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.4.0.tgz",
+      "integrity": "sha512-qpwO7Ihds/YYDTi1aADFTI1Sm9YC/tTe3SHD24EeIlZxy7Ik6a1b4HOz7jAi0xdUAw487duqpo8OGu+Tf4nwlQ=="
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "moment": "^2.29.4",
     "pinia": "^2.1.7",
     "plotly.js-dist-min": "^2.27.0",
+    "proj4": "^2.15.0",
     "proj4leaflet": "^1.0.2",
     "vue": "^3.3.4",
     "vue-router": "^4.2.5",

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -33,6 +33,7 @@ const baseLayerOptions = {
 onMounted(() => {
   map = L.map('map', getBaseMapAndLayers())
 
+  // Create a pane for the mask layer to sit on top of the data layer
   map.createPane('maskPane')
   map.getPane('maskPane').style.zIndex = 650
 
@@ -119,11 +120,8 @@ const getBaseMapAndLayers = function () {
     continuousWorld: true, // needed for non-3857 projs
     layers: ['arctic_osm_3572']
   })
-  // EPSG:3572 has strange bounds. These values were determined by using
-  // getBounds() on Leaflet's map object after loading a map in EPSG:3572,
-  // then tweaking the latitude values until the maxBounds behaved as
-  // expected. The maxBounds behavior isn't perfect, but maybe as good as it
-  // gets for the EPSG:3572 projection.
+  // EPSG:3572 has strange bounds. These values were chosen in another of our projects and
+  // seem to work well here as well.
   let southWest = L.latLng(20, -15)
   let northEast = L.latLng(20, 165)
 
@@ -135,13 +133,6 @@ const getBaseMapAndLayers = function () {
 
   // Map base configuration
   const bounds = L.latLngBounds(southWest, northEast)
-
-  const shadowMaskLayer = L.tileLayer.wms('https://gs.earthmaps.io/geoserver/wms', {
-    layers: ['hsia_mask'], // Layer name from your GeoServer
-    format: 'image/png',
-    transparent: true, // Set to true for overlay transparency
-    version: '1.3.0'
-  })
 
   // Map base configuration
   let layerConfig = {

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -112,7 +112,7 @@ var proj = new L.Proj.CRS(
 )
 
 const getBaseMapAndLayers = function () {
-  const baseLayer = new L.tileLayer.wms('https://gs.mapventure.org/geoserver/wms', {
+  const baseLayer = new L.tileLayer.wms('https://gs.earthmaps.io/geoserver/wms', {
     transparent: true,
     srs: 'EPSG:3572',
     format: 'image/png',


### PR DESCRIPTION
This PR ensures that the circular hsia_mask layer is always displayed above the hsia_arctic_production and base OSM layer. To achieve this, a new Leaflet pane with a higher z-index was created and assigned to the mask layer. The mask layer is now consistently rendered on top, improving the visual clarity of the data overlay.