### PR TITLE
Re-hydration of the app based on report URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,10 @@
       property="og:description"
       content="View historical sea ice data from the seas around the circumpolar north and discover how ice extent and concentration have changed over time."
     />
-    <meta property="og:image" content="https://snap.uaf.edu/tools/sea-ice-atlas/hsia-og-image.png" />
+    <meta
+      property="og:image"
+      content="https://snap.uaf.edu/tools/sea-ice-atlas/hsia-og-image.png"
+    />
     <link rel="icon" href="/favicon.ico" />
     <!-- TODO this stylesheet should be imported as a module dependency -->
     <link
@@ -35,9 +38,8 @@
         >We&rsquo;re sorry but this site doesn&rsquo;t work properly without JavaScript enabled.
         Please enable it to continue. If you have questions or want help accessing this content
         through different media, please email us at
-        <a href="mailto:uaf-snap-data-tools@alaska.edu">uaf-snap-data-tools@alaska.edu</a>.</strong>
-    </p>
-  </noscript>
-</body>
-
+        <a href="mailto:uaf-snap-data-tools@alaska.edu">uaf-snap-data-tools@alaska.edu</a>.</strong
+      >
+    </noscript>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       content="View historical sea ice data from the seas around the circumpolar north and discover how ice extent and concentration have changed over time."
     />
     <meta property="og:image" content="https://snap.uaf.edu/tools/sea-ice-atlas/hsia-og-image.png" />
-    <link rel="icon" href="favicon.ico" />
+    <link rel="icon" href="/favicon.ico" />
     <!-- TODO this stylesheet should be imported as a module dependency -->
     <link
       rel="stylesheet"

--- a/src/components/Report.vue
+++ b/src/components/Report.vue
@@ -29,12 +29,7 @@ import ConcentrationPlot from './ConcentrationPlot.vue'
 import Tapestry from './Tapestry.vue'
 import LoadingBlock from './LoadingBlock.vue'
 import { useAtlasStore } from '@/stores/atlas'
-import { onBeforeMount, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 const atlasStore = useAtlasStore()
 const { isLoaded } = storeToRefs(atlasStore)
-
-onBeforeMount(() => {
-  atlasStore.fetch()
-})
 </script>

--- a/src/components/Report.vue
+++ b/src/components/Report.vue
@@ -30,6 +30,18 @@ import Tapestry from './Tapestry.vue'
 import LoadingBlock from './LoadingBlock.vue'
 import { useAtlasStore } from '@/stores/atlas'
 import { storeToRefs } from 'pinia'
+import { onBeforeMount } from 'vue'
 const atlasStore = useAtlasStore()
 const { isLoaded } = storeToRefs(atlasStore)
+
+const props = defineProps(['lat', 'lng'])
+
+onBeforeMount(() => {
+  if (props.lat && props.lng) {
+    const latNum = parseFloat(props.lat)
+    const lngNum = parseFloat(props.lng)
+    atlasStore.setLatLngFromObject({ lat: latNum, lng: lngNum })
+    atlasStore.fetch()
+  }
+})
 </script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,8 +1,8 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
+import { createRouter, createWebHistory } from 'vue-router'
 import MapView from '../views/MapView.vue'
 
 const router = createRouter({
-  history: createWebHashHistory(),
+  history: createWebHistory(),
   routes: [
     {
       path: '/',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,8 +1,8 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHashHistory } from 'vue-router'
 import MapView from '../views/MapView.vue'
 
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHashHistory(),
   routes: [
     {
       path: '/',

--- a/src/views/ReportView.vue
+++ b/src/views/ReportView.vue
@@ -18,10 +18,20 @@ import Report from '../components/Report.vue'
 import BackButton from '../components/BackButton.vue'
 import { useAtlasStore } from '@/stores/atlas'
 import { storeToRefs } from 'pinia'
+import { onBeforeMount } from 'vue'
 const atlasStore = useAtlasStore()
 const { validMapPixel } = storeToRefs(atlasStore)
 
 // This will parse/set the lat/lng if it's being supplied via URL.
 // TBD << reconstituting this from URL via rewrite/traps
 const props = defineProps(['lat', 'lng'])
+
+onBeforeMount(() => {
+  if (props.lat && props.lng) {
+    const latNum = parseFloat(props.lat)
+    const lngNum = parseFloat(props.lng)
+    atlasStore.setLatLngFromObject({ lat: latNum, lng: lngNum })
+    atlasStore.fetch()
+  }
+})
 </script>

--- a/src/views/ReportView.vue
+++ b/src/views/ReportView.vue
@@ -22,8 +22,6 @@ import { onBeforeMount } from 'vue'
 const atlasStore = useAtlasStore()
 const { validMapPixel } = storeToRefs(atlasStore)
 
-// This will parse/set the lat/lng if it's being supplied via URL.
-// TBD << reconstituting this from URL via rewrite/traps
 const props = defineProps(['lat', 'lng'])
 
 onBeforeMount(() => {

--- a/src/views/ReportView.vue
+++ b/src/views/ReportView.vue
@@ -5,7 +5,7 @@
       <ReportTitle v-bind:class="{ 'is-hidden': !validMapPixel }" />
       <LoadingBlock />
       <InvalidPlace />
-      <Report v-bind:class="{ 'is-hidden': !validMapPixel }" />
+      <Report v-bind:class="{ 'is-hidden': !validMapPixel }" :lat="props.lat" :lng="props.lng" />
     </div>
   </section>
 </template>
@@ -18,18 +18,8 @@ import Report from '../components/Report.vue'
 import BackButton from '../components/BackButton.vue'
 import { useAtlasStore } from '@/stores/atlas'
 import { storeToRefs } from 'pinia'
-import { onBeforeMount } from 'vue'
 const atlasStore = useAtlasStore()
 const { validMapPixel } = storeToRefs(atlasStore)
 
 const props = defineProps(['lat', 'lng'])
-
-onBeforeMount(() => {
-  if (props.lat && props.lng) {
-    const latNum = parseFloat(props.lat)
-    const lngNum = parseFloat(props.lng)
-    atlasStore.setLatLngFromObject({ lat: latNum, lng: lngNum })
-    atlasStore.fetch()
-  }
-})
 </script>


### PR DESCRIPTION
Closes #80 

This PR adds re-hydration of the HSIA app based on the report URL. To accomplish this, we needed to use the WebHashHistory functionality of the vue-router software to allow for client-side generation of these reports. This still allows for hitting back and forth in a browser window to go between reports / home page of the application.

Try a few locations and ensure that if you reload the page you are seeing the report displaying properly.