### PR TITLE
Clear store data on map entry & fixes Toksook lat / lon 

### DIFF
--- a/src/communities.js
+++ b/src/communities.js
@@ -179,7 +179,7 @@ export default {
         name: 'Togiak, AK'
       },
       {
-        place: '60.5,-165.11',
+        place: '60.25,-165.06',
         name: 'Toksook Bay, AK'
       },
       {

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -59,6 +59,10 @@ onMounted(() => {
   }).addTo(map)
   updateAtlas()
   map.invalidateSize()
+
+  // This ensures that when the map is shown, it will clear the previous report data
+  // including community name, lat, lon, and data.
+  atlasStore.clearReport()
 })
 
 watch([year, month], () => {

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -59,10 +59,6 @@ onMounted(() => {
   }).addTo(map)
   updateAtlas()
   map.invalidateSize()
-
-  // This ensures that when the map is shown, it will clear the previous report data
-  // including community name, lat, lon, and data.
-  atlasStore.clearReport()
 })
 
 watch([year, month], () => {

--- a/src/components/Report.vue
+++ b/src/components/Report.vue
@@ -29,8 +29,8 @@ import ConcentrationPlot from './ConcentrationPlot.vue'
 import Tapestry from './Tapestry.vue'
 import LoadingBlock from './LoadingBlock.vue'
 import { useAtlasStore } from '@/stores/atlas'
+import { onBeforeMount, onUnmounted } from 'vue'
 import { storeToRefs } from 'pinia'
-import { onBeforeMount } from 'vue'
 const atlasStore = useAtlasStore()
 const { isLoaded } = storeToRefs(atlasStore)
 
@@ -43,5 +43,10 @@ onBeforeMount(() => {
     atlasStore.setLatLngFromObject({ lat: latNum, lng: lngNum })
     atlasStore.fetch()
   }
+})
+
+onUnmounted(() => {
+  // This ensures that when the report is closed, it will clear the report data
+  atlasStore.clearReport()
 })
 </script>

--- a/src/stores/atlas.js
+++ b/src/stores/atlas.js
@@ -58,6 +58,12 @@ export const useAtlasStore = defineStore('atlas', {
     }
   },
   actions: {
+    clearReport() {
+      this.apiData = []
+      this.community = undefined
+      this.lat = undefined
+      this.lng = undefined
+    },
     // Decrement month, going to prior year if necessary, but prevent
     // going before January 1850.
     decrementMonth() {


### PR DESCRIPTION
This PR adds a step to clear the report data after the Map component has been mounted. This prevents the possibility of going into a community, clicking either the back button on the browser, or the back button in the application and then clicking on a point on the map and still seeing the name of the community shown.

Additionally, this PR fixes the lat / lon of the Toksook, Alaska community to the nearest available pixel with data. 

Closes #74 