### PR TITLE
Remove underline from map controls, and slightly fix position

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -159,4 +159,13 @@ const getBaseMapAndLayers = function () {
 #map {
   height: 90vh;
 }
+:deep(.leaflet-control-zoom a) {
+	text-decoration: none !important;
+	span {
+		display: inline-block;
+		position: relative;
+		bottom: 2px;
+		right: 1px;
+	}
+}
 </style>


### PR DESCRIPTION
Closes #83 

Look at the zoom controls: no longer underlined and better centered