### PR TITLE
Improve error handling, target location on page with scroll behavior

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -6,11 +6,16 @@ h2,
 h3,
 h4,
 h5,
+ul,
 label,
 footer,
 .title {
   font-family: 'Libre Caslon Text', serif;
   color: #112951;
+}
+
+li {
+  list-style: none;
 }
 
 a {

--- a/src/components/BackButton.vue
+++ b/src/components/BackButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <router-link to="/" class="mb-6"><a class="button is-link">
+  <router-link :to="{ path: '/', hash: '#place' }" class="mb-6"><a class="button is-link">
     <span class="icon is-large">
       <i class="fas fa-arrow-left"></i>
     </span>

--- a/src/components/CommunityPicker.vue
+++ b/src/components/CommunityPicker.vue
@@ -44,7 +44,8 @@ watch(community, (newCommunity) => {
     params: {
       lat: lat.value,
       lng: lng.value
-    }
+    },
+    hash: '#report'
   })
 })
 </script>

--- a/src/components/InvalidPlace.vue
+++ b/src/components/InvalidPlace.vue
@@ -1,29 +1,41 @@
 <template>
-  <div class="report--invalid" v-bind:class="{ 'is-hidden': validMapPixel }">
-    <p class="is-size-5 mb-3">
-      <strong>Sorry, the place you clicked on the map doesn&rsquo;t show any sea ice data.</strong>
+  <div class="report--invalid content is-size-5" v-bind:class="{ 'is-hidden': validMapPixel }">
+    <p class="is-size-5 mt-6 mb-3 sorry">
+      <strong>This sea ice dataset<br>doesn&rsquo;t show any recorded sea ice<br>in this place.</strong>
     </p>
-    <p class="is-size-5 mb-3 reasons">
-      This can be for a few different reasons:<br />it is too far south and never has sea ice,<br />it&rsquo;s
-      on land,<br />or it&rsquo;s outside of the extent of this dataset.
+    <p class="is-size-5 mt-5 mb-3 reasons">
+      This can be for a few different reasons:
     </p>
-    <p class="is-size-5 mb-6">Zooming in on the map can make it easier to choose a location.</p>
-    <p class="is-size-4">
-      <router-link to="/">Go back and pick another place on the map.</router-link>
-    </p>
+      <ul class="mt-1">
+        <li>it is too far south and <strong>never has sea ice</strong>,</li>
+        <li>it&rsquo;s <strong>on land</strong>,</li>
+        <li>or it&rsquo;s <strong>outside of the extent of this dataset</strong>.</li>
+      </ul>
+    <BackButton />
   </div>
 </template>
 
 <style lang="scss" scoped>
+p.sorry strong {
+  font-size: 1.5rem;
+}
 p.reasons {
   line-height: 1.3;
   font-weight: 400;
+  font-size: 1.4rem !important;
+}
+ul {
+  margin: 0;
+  li {
+    margin: 0;
+  }
 }
 </style>
 
 <script setup>
 import { useAtlasStore } from '@/stores/atlas'
 import { storeToRefs } from 'pinia'
+import BackButton from '../components/BackButton.vue'
 const atlasStore = useAtlasStore()
 const { validMapPixel } = storeToRefs(atlasStore)
 </script>

--- a/src/components/LoadingBlock.vue
+++ b/src/components/LoadingBlock.vue
@@ -1,13 +1,25 @@
 <template>
-  <div class="loading-spinner box" v-bind:class="{ 'is-hidden': isLoaded }">
-    <div class="loading-spinner--wrapper">
-      <span class="icon is-large">
+  <div class="" v-bind:class="{ 'is-hidden': isLoaded }">
+    <p class="loading mt-4">
+      <span class="icon is-large mr-2">
         <i class="fas fa-spin fa-2x fa-spinner"></i>
       </span>
-      <span class="text"> Loading data for this point, hang on&hellip; </span>
-    </div>
+      <span class="text"> <strong>Loading data</strong> for this point, hang on&hellip; </span>
+    </p>
   </div>
 </template>
+
+<style lang="scss">
+.loading {
+  font-size: 1.3rem;
+
+  .icon {
+    display: inline-block;
+    position: relative;
+    top: 0.4rem;
+  }
+}
+</style>
 
 <script setup>
 import { useAtlasStore } from '@/stores/atlas'

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -72,7 +72,8 @@ const handleMapClick = function (event) {
     params: {
       lat: lat.value,
       lng: lng.value
-    }
+    },
+    hash: '#report'
   })
 }
 

--- a/src/components/Report.vue
+++ b/src/components/Report.vue
@@ -1,26 +1,24 @@
 <template>
-  <div class="content is-size-4 mt-6">
-    <p>
-      The charts below show two different ways of seeing changes<br />in sea ice concentration over
-      time.
-    </p>
-  </div>
-  <div class="content is-size-5">
-    <p>
-      Click the
-      <CameraIcon />
-      icon in the upper-right of each chart to download it.
-    </p>
-    <p>
-      Or,
-      <a :href="downloadButtonData">download data for this place (CSV).</a>
-    </p>
-    <div v-if="isLoaded">
+  <div id="report" :class="{ 'is-hidden': isHidden }" v-if="isLoaded">
+    <div class="content is-size-4 mt-6">
+      <p>
+        The charts below show two different ways of seeing changes<br />in sea ice concentration
+        over time.
+      </p>
+    </div>
+    <div class="content is-size-5">
+      <p>
+        Click the
+        <CameraIcon />
+        icon in the upper-right of each chart to download it.
+      </p>
+      <p>
+        Or,
+        <a :href="downloadButtonData">download data for this place (CSV).</a>
+      </p>
+
       <ConcentrationPlot />
       <Tapestry />
-    </div>
-    <div v-else>
-      <LoadingBlock />
     </div>
   </div>
 </template>
@@ -36,7 +34,7 @@ import { storeToRefs } from 'pinia'
 const atlasStore = useAtlasStore()
 const { isLoaded } = storeToRefs(atlasStore)
 
-const props = defineProps(['lat', 'lng'])
+const props = defineProps(['lat', 'lng', 'isHidden'])
 
 onBeforeMount(() => {
   if (props.lat && props.lng) {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,7 +20,16 @@ const router = createRouter({
     },
     // Redirect not-found to home page
     { path: '/:pathMatch(.*)*', name: 'NotFound', redirect: '/' }
-  ]
+  ],
+  // Scroll just above the map / report when you navigate
+  scrollBehavior(to, from, savedPosition) {
+    if (to.hash) {
+      return {
+        el: to.hash,
+        behavior: 'smooth'
+      }
+    }
+  }
 })
 
 export default router

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -1,7 +1,7 @@
 <template>
   <main>
     <div>
-      <h5 class="mt-5 pt-3 pb-0 mb-0">To begin, choose a community or click on the map.</h5>
+      <h5 id="place" class="mt-5 pt-3 pb-0 mb-0">To begin, choose a community or click on the map.</h5>
       <div class="controls">
         <CommunityPicker class="is-hidden-portrait m-5" />
       </div>

--- a/src/views/ReportView.vue
+++ b/src/views/ReportView.vue
@@ -1,11 +1,11 @@
 <template>
-  <section class="section has-text-centered">
+  <section class="section has-text-centered" id="report">
     <div class="container">
       <BackButton />
-      <ReportTitle v-bind:class="{ 'is-hidden': !validMapPixel }" />
+      <ReportTitle />
       <MiniMap />
       <LoadingBlock />
-      <InvalidPlace />
+      <InvalidPlace v-bind:class="{ 'is-hidden': validMapPixel }" />
       <Report v-bind:class="{ 'is-hidden': !validMapPixel }" :lat="props.lat" :lng="props.lng" />
     </div>
   </section>


### PR DESCRIPTION
Closes #103 
Closes #102 

Testing: run the app as normal.

- Pick a community.  The app should switch to the Report view, with the viewport centered so the "Back to the map" button is at the top.
- Click "Back to the map."  You should see the "To get started..." within the viewport (it may smooth-scroll there)
- Click somewhere way down south where there is no sea ice
- You should get the report properly framed in the viewport, with an improved "There is nothing here" message (language and formatting).  No chart/tapestry should be visible now.

Changes to look out for:
- There's now a #hash in the URL to ensure proper scroll position behavior.  Do we hate that?
- I removed a duplicate "Loading..." component, just kept the one at the top
- I fixed show/hide behavior for a number of subcomponents.
