### PR TITLE
Uses the API to determine the maximum year and month that we have data for

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,11 @@ import Header from './components/Header.vue'
 import Intro from './components/Intro.vue'
 import Footer from './components/Footer.vue'
 import '@fortawesome/fontawesome-free/css/all.css'
+import { useAtlasStore } from '@/stores/atlas'
+
+const { getMaxYearAndMonth } = useAtlasStore()
+getMaxYearAndMonth() // update to most current temporal extent!
+
 </script>
 
 <template>
@@ -41,7 +46,7 @@ import '@fortawesome/fontawesome-free/css/all.css'
       <h5 class="is-size-4 has-text-weight-bold mb-5">Watch sea ice concentration animations</h5>
       <div class="columns">
         <div class="column is-half">
-          <h5>Every month, {{ MIN_YEAR }}&ndash;2019</h5>
+          <h5>Every month, 1850&ndash;2019</h5>
           <iframe
             src="https://www.youtube-nocookie.com/embed/XSa0iGU0uDY"
             frameborder="0"
@@ -50,7 +55,7 @@ import '@fortawesome/fontawesome-free/css/all.css'
           ></iframe>
         </div>
         <div class="column is-half">
-          <h5>Monthly playlist, e.g. each January, {{ MIN_YEAR }}&ndash;2019</h5>
+          <h5>Monthly playlist, e.g. each January, 1850&ndash;2019</h5>
           <iframe
             src="https://www.youtube-nocookie.com/embed/videoseries?list=PLHlhXw356_VfeMkTxZHrOx_qSf_ZqrSGW"
             frameborder="0"
@@ -120,10 +125,6 @@ import '@fortawesome/fontawesome-free/css/all.css'
     <Footer />
   </div>
 </template>
-
-<script>
-import { MIN_YEAR, MAX_YEAR } from '@/shared.js'
-</script>
 
 <style lang="scss" scoped>
 iframe {

--- a/src/components/ConcentrationPlot.vue
+++ b/src/components/ConcentrationPlot.vue
@@ -16,7 +16,9 @@ import _ from 'lodash'
 import { ref, computed, watch, toRaw, onMounted } from 'vue'
 import { useAtlasStore } from '@/stores/atlas'
 import { storeToRefs } from 'pinia'
-import { xrange, plotSettings, MIN_YEAR, MAX_YEAR } from '@/shared.js'
+
+import { plotSettings } from '@/shared.js'
+const { xrange, MIN_YEAR, MAX_YEAR } = useAtlasStore()
 
 const atlasStore = useAtlasStore()
 const { apiData, isLoaded } = storeToRefs(atlasStore)

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,6 +1,9 @@
 <script setup>
 import { useAtlasStore } from '@/stores/atlas'
-const { displayMaxDate } = useAtlasStore()
+import { storeToRefs } from 'pinia'
+const atlasStore = useAtlasStore()
+const { displayMaxDate } = storeToRefs(atlasStore)
+
 </script>
 
 <template>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { MAX_YEAR } from '@/shared.js'
+import { useAtlasStore } from '@/stores/atlas'
+const { displayMaxDate } = useAtlasStore()
 </script>
 
 <template>
@@ -15,7 +16,7 @@ import { MAX_YEAR } from '@/shared.js'
           Sea Ice Atlas
         </h1>
         <h2 class="mt-4">for <span>Alaska</span> &amp; the <span>Arctic</span></h2>
-        <h3 class="mt-2">1850 to {{ MAX_YEAR }}</h3>
+        <h3 class="mt-2">1850 to {{ displayMaxDate }}</h3>
       </div>
 
       <div class="column splash is-half">

--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -35,6 +35,7 @@
         <p>
           <a href="https://nsidc.org/cryosphere/quickfacts/seaice.html">Learn more about sea ice</a>
         </p>
+        <p class="available is-size-4 mt-5">Data are available through {{ displayMaxDate }}.</p>
       </div>
     </section>
   </div>
@@ -77,3 +78,8 @@ section.lede {
   }
 }
 </style>
+
+<script setup>
+import { useAtlasStore } from '@/stores/atlas'
+const { displayMaxDate } = useAtlasStore()
+</script>

--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -81,5 +81,7 @@ section.lede {
 
 <script setup>
 import { useAtlasStore } from '@/stores/atlas'
-const { displayMaxDate } = useAtlasStore()
+import { storeToRefs } from 'pinia'
+const atlasStore = useAtlasStore()
+const { displayMaxDate } = storeToRefs(atlasStore)
 </script>

--- a/src/components/MonthSelectors.vue
+++ b/src/components/MonthSelectors.vue
@@ -17,11 +17,10 @@ import { storeToRefs } from 'pinia'
 import { useAtlasStore } from '@/stores/atlas'
 const atlasStore = useAtlasStore()
 const { incrementMonth, decrementMonth } = atlasStore
-const { year, month } = storeToRefs(atlasStore)
-import { MIN_YEAR, MAX_YEAR, MAX_MONTH } from '@/shared.js'
+const { year, month, MIN_YEAR, MAX_YEAR, MAX_MONTH } = storeToRefs(atlasStore)
 
 const pastButtonDisabled = computed(() => {
-  return year.value == MIN_YEAR && month.value == 0
+  return year.value == MIN_YEAR.value && month.value == 0
 })
 const nextButtonDisabled = computed(() => {
   return year.value == MAX_YEAR.value && month.value == MAX_MONTH.value

--- a/src/components/MonthSelectors.vue
+++ b/src/components/MonthSelectors.vue
@@ -18,12 +18,12 @@ import { useAtlasStore } from '@/stores/atlas'
 const atlasStore = useAtlasStore()
 const { incrementMonth, decrementMonth } = atlasStore
 const { year, month } = storeToRefs(atlasStore)
-import { MIN_YEAR, MAX_YEAR } from '@/shared.js'
+import { MIN_YEAR, MAX_YEAR, MAX_MONTH } from '@/shared.js'
 
 const pastButtonDisabled = computed(() => {
   return year.value == MIN_YEAR && month.value == 0
 })
 const nextButtonDisabled = computed(() => {
-  return year.value == MAX_YEAR && month.value == 5
+  return year.value == MAX_YEAR && month.value == MAX_MONTH
 })
 </script>

--- a/src/components/MonthSelectors.vue
+++ b/src/components/MonthSelectors.vue
@@ -24,6 +24,6 @@ const pastButtonDisabled = computed(() => {
   return year.value == MIN_YEAR && month.value == 0
 })
 const nextButtonDisabled = computed(() => {
-  return year.value == MAX_YEAR && month.value == MAX_MONTH
+  return year.value == MAX_YEAR.value && month.value == MAX_MONTH.value
 })
 </script>

--- a/src/components/ReportTitle.vue
+++ b/src/components/ReportTitle.vue
@@ -4,8 +4,6 @@
 
 <script setup>
 import { useAtlasStore } from '@/stores/atlas'
-import { storeToRefs } from 'pinia'
-import { MIN_YEAR, MAX_YEAR } from '@/shared.js'
 
 const atlasStore = useAtlasStore()
 </script>

--- a/src/components/Tapestry.vue
+++ b/src/components/Tapestry.vue
@@ -21,7 +21,9 @@ import _ from 'lodash'
 import { computed, watch, toRaw, onMounted } from 'vue'
 import { useAtlasStore } from '@/stores/atlas'
 import { storeToRefs } from 'pinia'
-import { xrange, plotSettings, MIN_YEAR } from '@/shared.js'
+
+import { plotSettings } from '@/shared.js'
+const { xrange, MIN_YEAR, MAX_YEAR } = useAtlasStore()
 
 const atlasStore = useAtlasStore()
 const { apiData } = storeToRefs(atlasStore)

--- a/src/components/YearSlider.vue
+++ b/src/components/YearSlider.vue
@@ -16,15 +16,18 @@ import _ from 'lodash'
 import VueSlider from 'vue-slider-component'
 import 'vue-slider-component/theme/default.css'
 import { useAtlasStore } from '@/stores/atlas'
-const { setYear, MIN_YEAR, MAX_YEAR } = useAtlasStore()
+import { storeToRefs } from 'pinia'
+const atlasStore = useAtlasStore()
+const { MIN_YEAR, MAX_YEAR } = storeToRefs(atlasStore)
+const { setYear } = useAtlasStore()
 
-let marks = ref([MIN_YEAR, 1875, 1900, 1925, 1950, 1975, 2000, MAX_YEAR.value])
+let marks = ref([MIN_YEAR.value, 1875, 1900, 1925, 1950, 1975, 2000, MAX_YEAR.value])
 
-let selectedYear = MIN_YEAR
+let selectedYear = MIN_YEAR.value
 
 // This watches for any changes to the MAX_YEAR value and updates the slider accordingly
 watch(MAX_YEAR, (newMaxYear) => {
-  marks.value = [MIN_YEAR, 1875, 1900, 1925, 1950, 1975, 2000, MAX_YEAR]
+  marks.value = [MIN_YEAR.value, 1875, 1900, 1925, 1950, 1975, 2000, MAX_YEAR.value]
 })
 
 const debouncedUpdate = _.debounce((year) => {

--- a/src/components/YearSlider.vue
+++ b/src/components/YearSlider.vue
@@ -2,7 +2,7 @@
   <div class="slider-wrapper">
     <VueSlider
       v-model="selectedYear"
-      max="2024"
+      :max="maxYear"
       min="1850"
       :marks="marks"
       v-on:change="debouncedUpdate"
@@ -11,6 +11,7 @@
 </template>
 
 <script setup>
+import { ref, watch } from 'vue'
 import _ from 'lodash'
 import VueSlider from 'vue-slider-component'
 import 'vue-slider-component/theme/default.css'
@@ -18,8 +19,16 @@ import { useAtlasStore } from '@/stores/atlas'
 const { setYear } = useAtlasStore()
 import { MIN_YEAR, MAX_YEAR } from '@/shared.js'
 
+let maxYear = ref(MAX_YEAR.value)
+let marks = ref([MIN_YEAR, 1875, 1900, 1925, 1950, 1975, 2000, MAX_YEAR.value])
+
 let selectedYear = MIN_YEAR
-const marks = [MIN_YEAR, 1875, 1900, 1925, 1950, 1975, 2000, MAX_YEAR]
+
+// This watches for any changes to the MAX_YEAR value and updates the slider accordingly
+watch(MAX_YEAR, (newMaxYear) => {
+  maxYear.value = newMaxYear
+  marks.value = [MIN_YEAR, 1875, 1900, 1925, 1950, 1975, 2000, newMaxYear]
+})
 
 const debouncedUpdate = _.debounce((year) => {
   setYear(year)

--- a/src/components/YearSlider.vue
+++ b/src/components/YearSlider.vue
@@ -2,7 +2,7 @@
   <div class="slider-wrapper">
     <VueSlider
       v-model="selectedYear"
-      :max="maxYear"
+      :max="MAX_YEAR"
       min="1850"
       :marks="marks"
       v-on:change="debouncedUpdate"
@@ -16,18 +16,15 @@ import _ from 'lodash'
 import VueSlider from 'vue-slider-component'
 import 'vue-slider-component/theme/default.css'
 import { useAtlasStore } from '@/stores/atlas'
-const { setYear } = useAtlasStore()
-import { MIN_YEAR, MAX_YEAR } from '@/shared.js'
+const { setYear, MIN_YEAR, MAX_YEAR } = useAtlasStore()
 
-let maxYear = ref(MAX_YEAR.value)
 let marks = ref([MIN_YEAR, 1875, 1900, 1925, 1950, 1975, 2000, MAX_YEAR.value])
 
 let selectedYear = MIN_YEAR
 
 // This watches for any changes to the MAX_YEAR value and updates the slider accordingly
 watch(MAX_YEAR, (newMaxYear) => {
-  maxYear.value = newMaxYear
-  marks.value = [MIN_YEAR, 1875, 1900, 1925, 1950, 1975, 2000, newMaxYear]
+  marks.value = [MIN_YEAR, 1875, 1900, 1925, 1950, 1975, 2000, MAX_YEAR]
 })
 
 const debouncedUpdate = _.debounce((year) => {

--- a/src/shared.js
+++ b/src/shared.js
@@ -1,23 +1,30 @@
 import axios from 'axios'
+import { ref } from 'vue'
 
 export const MIN_YEAR = 1850
-export let MAX_YEAR
-export let MAX_MONTH
+export const MAX_YEAR = ref(2022)
+export const MAX_MONTH = ref(11)
 
-export let xrange = []
+export const xrange = ref([])
+
+/**
+ * Fetch MAX_YEAR and MAX_MONTH from the API and update reactive variables.
+ */
 export async function getMaxYearAndMonth() {
   try {
     let queryUrl = import.meta.env.VITE_SNAP_API_URL + `/seaice/enddate/`
     let enddate = await axios.get(queryUrl, { timeout: 60000 }).catch((err) => {
       console.error(err)
     })
-    enddate = enddate.data
-    MAX_YEAR = Number(enddate['year'])
-    // Sets max month to 0-11 range rather than 1-12
-    MAX_MONTH = Number(enddate['month'] - 1)
 
-    for (let x = MIN_YEAR; x <= MAX_YEAR; x++) {
-      xrange.push(x)
+    enddate = enddate.data
+    MAX_YEAR.value = Number(enddate['year'])
+    // Sets max month to 0-11 range rather than 1-12
+    MAX_MONTH.value = Number(enddate['month']) - 1
+
+    xrange.value = [] // Clear xrange before populating it
+    for (let x = MIN_YEAR; x <= MAX_YEAR.value; x++) {
+      xrange.value.push(x)
     }
   } catch (error) {
     console.error('Error getting max year and month:', error)

--- a/src/shared.js
+++ b/src/shared.js
@@ -1,35 +1,3 @@
-import axios from 'axios'
-import { ref } from 'vue'
-
-export const MIN_YEAR = 1850
-export const MAX_YEAR = ref(2022)
-export const MAX_MONTH = ref(11)
-
-export let xrange = []
-
-export async function getMaxYearAndMonth() {
-  try {
-    let queryUrl = import.meta.env.VITE_SNAP_API_URL + `/seaice/enddate/`
-    let enddate = await axios.get(queryUrl, { timeout: 60000 }).catch((err) => {
-      console.error(err)
-    })
-
-    enddate = enddate.data
-    MAX_YEAR.value = Number(enddate['year'])
-    // Sets max month to 0-11 range rather than 1-12
-    MAX_MONTH.value = Number(enddate['month']) - 1
-
-    xrange = []
-    for (let x = MIN_YEAR; x <= MAX_YEAR.value; x++) {
-      xrange.push(x)
-    }
-  } catch (error) {
-    console.error('Error getting max year and month:', error)
-  }
-}
-
-getMaxYearAndMonth()
-
 export const plotSettings = {
   responsive: true, // changes the height / width dynamically for charts
   displayModeBar: true, // always show the camera icon

--- a/src/shared.js
+++ b/src/shared.js
@@ -1,12 +1,30 @@
-export const MIN_YEAR = 1850
-export const MAX_YEAR = 2024
+import axios from 'axios'
 
-// Range of years for x-axis in chart
-var xrange = []
-for (let x = MIN_YEAR; x <= MAX_YEAR; x++) {
-  xrange.push(x)
+export const MIN_YEAR = 1850
+export let MAX_YEAR
+export let MAX_MONTH
+
+export let xrange = []
+export async function getMaxYearAndMonth() {
+  try {
+    let queryUrl = import.meta.env.VITE_SNAP_API_URL + `/seaice/enddate/`
+    let enddate = await axios.get(queryUrl, { timeout: 60000 }).catch((err) => {
+      console.error(err)
+    })
+    enddate = enddate.data
+    MAX_YEAR = Number(enddate['year'])
+    // Sets max month to 0-11 range rather than 1-12
+    MAX_MONTH = Number(enddate['month'] - 1)
+
+    for (let x = MIN_YEAR; x <= MAX_YEAR; x++) {
+      xrange.push(x)
+    }
+  } catch (error) {
+    console.error('Error getting max year and month:', error)
+  }
 }
-export var xrange
+
+getMaxYearAndMonth()
 
 export const plotSettings = {
   responsive: true, // changes the height / width dynamically for charts

--- a/src/shared.js
+++ b/src/shared.js
@@ -5,11 +5,8 @@ export const MIN_YEAR = 1850
 export const MAX_YEAR = ref(2022)
 export const MAX_MONTH = ref(11)
 
-export const xrange = ref([])
+export let xrange = []
 
-/**
- * Fetch MAX_YEAR and MAX_MONTH from the API and update reactive variables.
- */
 export async function getMaxYearAndMonth() {
   try {
     let queryUrl = import.meta.env.VITE_SNAP_API_URL + `/seaice/enddate/`
@@ -22,9 +19,9 @@ export async function getMaxYearAndMonth() {
     // Sets max month to 0-11 range rather than 1-12
     MAX_MONTH.value = Number(enddate['month']) - 1
 
-    xrange.value = [] // Clear xrange before populating it
+    xrange = []
     for (let x = MIN_YEAR; x <= MAX_YEAR.value; x++) {
-      xrange.value.push(x)
+      xrange.push(x)
     }
   } catch (error) {
     console.error('Error getting max year and month:', error)

--- a/src/stores/atlas.js
+++ b/src/stores/atlas.js
@@ -2,8 +2,9 @@ import { defineStore } from 'pinia'
 import _ from 'lodash'
 import axios from 'axios'
 import mock from '@/mock.js'
-import { MIN_YEAR, MAX_YEAR } from '@/shared.js'
 import communities from '@/communities.js'
+import moment from 'moment'
+
 const formatLatLng = function (l) {
   return l.toPrecision(5)
 }
@@ -11,14 +12,18 @@ const formatLatLng = function (l) {
 export const useAtlasStore = defineStore('atlas', {
   state: () => {
     return {
-      year: MIN_YEAR,
+      year: 1850,
       month: 0, // 0 = January, etc
       community: undefined, // community object from @/src/communities.js
       lat: undefined,
       lng: undefined,
       apiData: [],
       isLoaded: false,
-      validMapPixel: false
+      validMapPixel: false,
+      xrange: [], // used in the Plotly code for both charts
+      MIN_YEAR: 1850,
+      MAX_YEAR: 2023, // sane default
+      MAX_MONTH: 11 // december, sane default
     }
   },
   getters: {
@@ -55,6 +60,10 @@ export const useAtlasStore = defineStore('atlas', {
         minYear: MIN_YEAR,
         maxYear: MAX_YEAR
       })
+    },
+    displayMaxDate: (state) => {
+      var dateObj = moment({ day: 1, month: state.MAX_MONTH, year: state.MAX_YEAR })
+      return dateObj.format('MMMM YYYY')
     }
   },
   actions: {
@@ -134,6 +143,27 @@ export const useAtlasStore = defineStore('atlas', {
         this.validMapPixel = false
       } else {
         this.validMapPixel = true
+      }
+    },
+    async getMaxYearAndMonth() {
+      try {
+        let queryUrl = import.meta.env.VITE_SNAP_API_URL + `/seaice/enddate/`
+        let enddate = await axios.get(queryUrl, { timeout: 60000 }).catch((err) => {
+          console.error(err)
+        })
+
+        enddate = enddate.data
+        this.MAX_YEAR = Number(enddate['year'])
+        // Sets max month to 0-11 range rather than 1-12
+        this.MAX_MONTH = Number(enddate['month']) - 1
+
+        this.xrange = []
+        for (let x = this.MIN_YEAR; x <= this.MAX_YEAR.value; x++) {
+          this.xrange.push(x)
+        }
+      } catch (error) {
+        // This is where we would swap the app into "broken" mode
+        console.error('Error getting max year and month:', error)
       }
     }
   }

--- a/src/stores/atlas.js
+++ b/src/stores/atlas.js
@@ -95,15 +95,15 @@ export const useAtlasStore = defineStore('atlas', {
 
     decrementYear() {
       this.year--
-      if (this.year < MIN_YEAR) {
-        this.year = MIN_YEAR
+      if (this.year < this.MIN_YEAR) {
+        this.year = this.MIN_YEAR
         this.setMonth(0) // reset to Jan
       }
     },
     incrementYear() {
       this.year++
-      if (this.year > MAX_YEAR) {
-        this.year = MAX_YEAR
+      if (this.year > this.MAX_YEAR) {
+        this.year = this.MAX_YEAR
         this.setMonth(11) // reset to Dec
       }
     },

--- a/src/stores/atlas.js
+++ b/src/stores/atlas.js
@@ -57,8 +57,8 @@ export const useAtlasStore = defineStore('atlas', {
       return template({
         placeName: placeName,
         latLng: latLng,
-        minYear: MIN_YEAR,
-        maxYear: MAX_YEAR
+        minYear: state.MIN_YEAR,
+        maxYear: state.MAX_YEAR
       })
     },
     displayMaxDate: (state) => {
@@ -158,7 +158,7 @@ export const useAtlasStore = defineStore('atlas', {
         this.MAX_MONTH = Number(enddate['month']) - 1
 
         this.xrange = []
-        for (let x = this.MIN_YEAR; x <= this.MAX_YEAR.value; x++) {
+        for (let x = this.MIN_YEAR; x <= this.MAX_YEAR; x++) {
           this.xrange.push(x)
         }
       } catch (error) {


### PR DESCRIPTION
This PR uses a new endpoint on the API that allows for this code to dynamically update its maximum year and month based on the data available within our data server. Currently, that maximum is year = 2024 and month = 6, but the next time we update the sea ice data, it will automatically recognize that there is new data to be displayed and adjust the year slider, month selector, and xrange for the charts accordingly. 

To test:

Have this version of the API running locally: https://github.com/ua-snap/data-api/pull/508
export VITE_SNAP_API_URL=http://localhost:5000
export VITE_WMS_URL=https://zeus.snap.uaf.edu/rasdaman/ows
npm run dev

Notice that the year slider has a maximum of 2024 and you can't go past the month of June. The charts should also all display properly given the correct range of values.

Closes #84 