### PR TITLE
Updates link for poster link to work when in a report.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,6 @@ import { useAtlasStore } from '@/stores/atlas'
 
 const { getMaxYearAndMonth } = useAtlasStore()
 getMaxYearAndMonth() // update to most current temporal extent!
-
 </script>
 
 <template>
@@ -34,7 +33,7 @@ getMaxYearAndMonth() // update to most current temporal extent!
       <h2 class="is-size-3 pb-3 has-text-weight-bold">Other ways to view sea ice data</h2>
       <div>
         <h5 class="is-size-5 mb-4">
-          <a href="Historical-Sea-Ice-Extents-Octobers.pdf" class="is-size-4 has-text-weight-bold"
+          <a href="/Historical-Sea-Ice-Extents-Octobers.pdf" class="is-size-4 has-text-weight-bold"
             >Download a poster</a
           ><br /><span
             >that shows 170 images of sea ice concentration for October, 1850&ndash;2019.</span


### PR DESCRIPTION
This PR updates the HREF for the poster to be from the root level of the site when in a report rather than trying to replace just the top level of the URL.

STR:
* Go to http://dev.seaiceatlas.org
* Click on a location on the map
* Click on the link "Download a poster" towards the bottom of the page

Expected: Opens the PDF of the poster
Actual: It screws up the URL and nothing is shown.

This PR pushes the URL to go from the root level and will fix this issue.