### PR TITLE
Update domain to seaiceatlas.org in Umami configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       async
       defer
       data-website-id="a8f7164d-7d69-496a-bc2f-076a59214eb5"
-      data-domains="snap.uaf.edu"
+      data-domains="seaiceatlas.org"
       src="https://umami.snap.uaf.edu/script.js"
       data-do-not-track="true"
     ></script>


### PR DESCRIPTION
Closes #113.

This PR simply updates the domain enforcement in the webapp's Umami configuration to use the new seaiceatlas.org domain. I've also updated the the Historical Sea Ice Atlas website settings on the Umami server to recognize this domain.