### PR TITLE
Fix CSV download link

### DIFF
--- a/src/components/Report.vue
+++ b/src/components/Report.vue
@@ -14,7 +14,7 @@
       </p>
       <p>
         Or,
-        <a :href="downloadButtonData">download data for this place (CSV).</a>
+        <a :href="atlasStore.getCsvUrl">download data for this place (CSV).</a>
       </p>
 
       <ConcentrationPlot />

--- a/src/stores/atlas.js
+++ b/src/stores/atlas.js
@@ -64,6 +64,10 @@ export const useAtlasStore = defineStore('atlas', {
     displayMaxDate: (state) => {
       var dateObj = moment({ day: 1, month: state.MAX_MONTH, year: state.MAX_YEAR })
       return dateObj.format('MMMM YYYY')
+    },
+    getCsvUrl: (state) => {
+      let csvUrl = import.meta.env.VITE_SNAP_API_URL + `/seaice/point/${state.lat}/${state.lng}?format=csv`
+      return csvUrl
     }
   },
   actions: {


### PR DESCRIPTION
Closes #115.

This PR fixes the CSV download link by constructing and loading it from the store.

To test, run the app like this:

```
export VITE_WMS_URL=https://zeus.snap.uaf.edu/rasdaman/ows
npm run dev
```

Then click a location to load its report page, then click the CSV download link.