### PR TITLE
 De-duplicate Makkovik, NL and Mary's Harbour, NL

### DIFF
--- a/src/communities.js
+++ b/src/communities.js
@@ -489,14 +489,6 @@ export default {
         name: 'Lodge Bay, NL'
       },
       {
-        place: '55.23,-58.33',
-        name: 'Makkovik, NL'
-      },
-      {
-        place: '52.33,-55.31',
-        name: "Mary's Harbour, NL"
-      },
-      {
         place: '56.54,-61.26',
         name: 'Nain, NL'
       },
@@ -546,7 +538,7 @@ export default {
         name: "Mary's Harbour, NL"
       },
       {
-        place: '55.20,-58.78',
+        place: '55.09,-59.18',
         name: 'Makkovik, NL'
       },
       {

--- a/src/communities.js
+++ b/src/communities.js
@@ -489,6 +489,14 @@ export default {
         name: 'Lodge Bay, NL'
       },
       {
+        place: '55.09,-59.18',
+        name: 'Makkovik, NL'
+      },
+      {
+        place: '52.30,-55.18',
+        name: "Mary's Harbour, NL"
+      },
+      {
         place: '56.54,-61.26',
         name: 'Nain, NL'
       },
@@ -532,14 +540,6 @@ export default {
       {
         place: '51.34,-55.38',
         name: 'St. Anthony, NL'
-      },
-      {
-        place: '52.30,-55.18',
-        name: "Mary's Harbour, NL"
-      },
-      {
-        place: '55.09,-59.18',
-        name: 'Makkovik, NL'
       },
       {
         place: '50.67,-55.93',


### PR DESCRIPTION
This PR de-duplicates two duplicated communities: Makkovik, NL, and Mary's Harbour, NL. These were both listed under the "Newfoundland" and the "Labrador" categories. The Newfoundland items were dropped, and the Labrador items were retained. The lat-lon for Makkovik was modified per the suggestion of @MikeDelue , and the retained lat-lons return data when tested against the API branch referenced here and now merged into main.

Closes #128 
Closes #127 

XREF https://github.com/ua-snap/data-api/pull/714