### PR TITLE
Adds clarifying text regarding data added since 2019.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -78,7 +78,8 @@ getMaxYearAndMonth() // update to most current temporal extent!
           Atlas data begin with sea ice observations extrapolated from whaling ship log books<br />
           in the Beaufort, Chukchi, and Bering seas starting in {{ MIN_YEAR }}.<br />
           Estimates are used to fill gaps in log book data.<br />
-          Other data sources are incorporated as they were developed over time.
+          Other data sources are incorporated as they were developed over time.<br />
+          <strong>Data added since 2019 come from the NSIDC.</strong>
         </p>
       </div>
       <img


### PR DESCRIPTION
This PR adds a small amount of text to clarify that the data has been coming from NSIDC since 2019. This is to prevent the need to update the image that is shown regarding our incoming data sources. 

Closes #130 