### PR TITLE
Improves back button text and placement

### DIFF
--- a/src/components/BackButton.vue
+++ b/src/components/BackButton.vue
@@ -1,10 +1,11 @@
 <template>
-  <router-link :to="{ path: '/', hash: '#place' }" class="mb-6"><a class="button is-link">
-    <span class="icon is-large">
-      <i class="fas fa-arrow-left"></i>
-    </span>
-    <span class="text"> Back to the map </span>
-  </a>
+  <router-link :to="{ path: '/', hash: '#place' }" class="mb-6"
+    ><a class="button is-link">
+      <span class="icon is-large">
+        <i class="fas fa-arrow-left"></i>
+      </span>
+      <span class="text"> Pick another place </span>
+    </a>
   </router-link>
 </template>
 

--- a/src/views/ReportView.vue
+++ b/src/views/ReportView.vue
@@ -7,6 +7,7 @@
       <LoadingBlock />
       <InvalidPlace v-bind:class="{ 'is-hidden': validMapPixel }" />
       <Report v-bind:class="{ 'is-hidden': !validMapPixel }" :lat="props.lat" :lng="props.lng" />
+      <BackButton />
     </div>
   </section>
 </template>


### PR DESCRIPTION
This PR updates the back button text to state 'Pick another place' rather than 'Back to the map' in case someone comes to the report from a URL with the place already selected. Additionally, this adds another back button to the bottom of the report for when people scroll to the end of the report so that they don't have to scroll all the way back to the top of the report to go to another location.

Closes #93 